### PR TITLE
Lea Verou Tokyo TAG F2F travel expenses

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -4,3 +4,4 @@
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
 | Claudio | Wunder | OpenJS World | Collab Summit Organisation + Programmee Committee | TBD | Vancouver | 8th May - 16th May | 700 EUR | March 1st | https://github.com/openjs-foundation/cross-project-council/pull/1018 | TBD | TBD | TBD | TBD | TBD |
 | Christian | Bromann | OpenJS World | Collab Summit Organisation + Programmee Committee | TBD | Vancouver | 5th May - 13th May | 800 EUR | March 24th | https://github.com/openjs-foundation/cross-project-council/pull/1035 | TBD | TBD | TBD | TBD | TBD |
+| Lea | Verou | TAG F2F | TAG Member | TBD | Tokyo, Japan | April 17-21 | $3500 | March 27th | TBD | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
First TAG f2F since July 2022!

Sadly, it appears I left this rather late: the combination of the 22nd being a very busy weekend in Tokyo + flying from ATH + my date, time and other constraints has made the flights fairly pricey (particularly the return). I don't have a specific itinerary yet, but from what I've seen this amount should cover a somewhat reasonable flight, especially if I keep accommodation & meal costs low (considering sharing an airbnb with other TAG members).

Thanks again OpenJS for covering my TAG travel! 