### PR TITLE
DS OJS World 2023 travel reimbursement

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -5,3 +5,4 @@
 | Claudio | Wunder | OpenJS World | Collab Summit Organisation + Programmee Committee | TBD | Vancouver | 8th May - 16th May | 700 EUR | March 1st | https://github.com/openjs-foundation/cross-project-council/pull/1018 | TBD | TBD | TBD | TBD | TBD |
 | Christian | Bromann | OpenJS World | Collab Summit Organisation + Programmee Committee | TBD | Vancouver | 5th May - 13th May | 800 EUR | March 24th | https://github.com/openjs-foundation/cross-project-council/pull/1035 | TBD | TBD | TBD | TBD | TBD |
 | Lea | Verou | TAG F2F | TAG Member | TBD | Tokyo, Japan | April 17-21 | $3500 | March 27th | TBD | TBD | TBD | TBD | TBD | TBD |
+| Dylan | Schiemann | OpenJS World | Program Committee & yoga session | TBD | Vancouver | 8th May - 13th May | 2376 USD | March 30th | https://github.com/openjs-foundation/community-fund/pull/18 | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
Looking at other requests, I have no idea how everyone has made their travel so affordable for this year's event unless they're requesting partial reimbursement and their company is covering the rest?

Hotel, May 8-13, 5 nights,
289 CDN + 21% tax (conf group rate)
213.54 + 21%
US $1389

Flight, PHX-VYR, economy
US $917

Ground transport to/from airport:
US $70

My role, as I'm not speaking this year and haven't been particularly active with the CPC:

* Active member of the program committee
* Leading the yoga session(s)
* Our startup just joined as a silver member

I've really never seen travel be this expensive before (flights are cheaper from Europe than from Phoenix) and I feel terrible submitting this request.

If it's too excessive, just let me know. It's not a must that I attend and I wouldn't be able to justify the cost given that I'm working on a startup.