### PR TITLE
Travel request for OpenJS World North America

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -7,3 +7,4 @@
 | Lea | Verou | TAG F2F | TAG Member | TBD | Tokyo, Japan | April 17-21 | $3500 | March 27th | TBD | TBD | TBD | TBD | TBD | TBD |
 | Dylan | Schiemann | OpenJS World | Program Committee & yoga session | TBD | Vancouver | 8th May - 13th May | 2376 USD | March 30th | https://github.com/openjs-foundation/community-fund/pull/18 | TBD | TBD | TBD | TBD | TBD |
 | Jordan | Harband | OpenJS World | attendance + Collab Summit | TBD | Vancouver | 8th May - 16th May | 1445 CAD (hotel) + $387.10 USD (flight) + ~$100 USD (transportation) | March 6th | https://github.com/openjs-foundation/cross-project-council/pull/1019 | TBD | TBD | TBD | TBD | TBD |
+| Bryan | Hughes | OpenJS World | Speaking | TBD | Vancouver | 9th May - 13th May | 1,539.81 CAD (hotel) + $364.31 USD (flight) | March 7th | https://github.com/openjs-foundation/community-fund/pull/22 | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
Hi @openjs-foundation/cpc, I'm a last minute speaking invite for OpenJS World North America in Vancouver, CA on May 10th through 12th. I unfortunately don't have funds to cover travel, and was instructed to submit a request for funds here. My talk will be titled "To Rewrite, or Not to Rewrite, That Is the Question."

I'm requesting hotel and airfare, which is $1503.58 USD as of this writing based on current costs and exchange rates. Let me know if you need to know anything more!