### PR TITLE
feat: add codys travel fund request

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -11,3 +11,4 @@
 | Ilya | Boyandin | [FOSS4G](https://2023.foss4g.org/) | [giving a talk](https://talks.osgeo.org/foss4g-2023/talk/review/CPDDPVUGSXUSTQ3JKS3H3ZWWUEQBSNSK) | TBD | Prizren, Kosovo | 28-30 June | EUR 490 registration fee + EUR ~400 flight + EUR ~300 hotel | April 4th | | TBD | TBD | TBD | TBD | TBD |
 | Paolo | Insogna| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 12th | 1190.23 EUR (Hotel) | Apr 13th, 2023 | TBD | TBD | TBD | TBD | TBD | TBD |
 | Ruy | Adorno| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 13th | 1282 USD (hotel) + 528 USD (flight) | Apr 25th, 2023 | https://github.com/openjs-foundation/community-fund/pull/25 | TBD | TBD | TBD | TBD | TBD |
+| Cody | Zuschlag | OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 7th - May 14th | 1848.66 EUR (Hotel) | Apr 13th, 2023 | TBD | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
I previously applied to speak at Collab summit (still await decision on https://github.com/openjs-foundation/summit/issues/353 ).

I was also accepted to speak at the Open Source Summit, but was later informed that was an error and was un-accepted. However, I did receive a comp'ed free ticket for OpenJS World and I plan to attend the OpenJS collab summit since my employer NearForm is part of the OpenJS foundation and I regularly attend the OpenJS CPC meetings.

Unfortunately, my employer, NearForm, has restricted travel for Q2. My employer is willing to pick up the cost of the flights (already booked) if I can find some funding for the hotel. I am in the same situation as my colleague @ShogunPanda (see https://github.com/openjs-foundation/community-fund/pull/23 ).

Please consider my request to pay for my stay at the hotel during the collab summit and open source summit.

The total amount for the stay at the hotel is EUR 1848.66.

Thank you for your consideration 🙏 

cc @openjs-foundation/cpc
cc @ovflowd