### PR TITLE
Travel fund request: OSS Summit NA - Ruy Adorno

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -10,3 +10,4 @@
 | Bryan | Hughes | OpenJS World | Speaking | TBD | Vancouver | 9th May - 13th May | 1,539.81 CAD (hotel) + $364.31 USD (flight) | March 7th | https://github.com/openjs-foundation/community-fund/pull/22 | TBD | TBD | TBD | TBD | TBD |
 | Ilya | Boyandin | [FOSS4G](https://2023.foss4g.org/) | [giving a talk](https://talks.osgeo.org/foss4g-2023/talk/review/CPDDPVUGSXUSTQ3JKS3H3ZWWUEQBSNSK) | TBD | Prizren, Kosovo | 28-30 June | EUR 490 registration fee + EUR ~400 flight + EUR ~300 hotel | April 4th | | TBD | TBD | TBD | TBD | TBD |
 | Paolo | Insogna| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 12th | 1190.23 EUR (Hotel) | Apr 13th, 2023 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Ruy | Adorno| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 13th | 1282 USD (hotel) + 528 USD (flight) | Apr 25th, 2023 | https://github.com/openjs-foundation/community-fund/pull/25 | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
**Travel Fund request for OSS Summit NA 2023**
**Dates:** 8 May - 13 May
**Traveling from:** Montreal, Canada
**Flight:** 528 USD
**Hotel:** 1282 USD
**Total:** 1810 USD

Unfortunately I couldn't secure the  funding from my employer. I'll cover all other costs like local transportation and food. No additional expensing is needed.

cc @openjs-foundation/cpc
cc @ovflowd 