### PR TITLE
Travel Expenses for OpenJS World, Chris Gervang

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -11,3 +11,4 @@
 | Ilya | Boyandin | [FOSS4G](https://2023.foss4g.org/) | [giving a talk](https://talks.osgeo.org/foss4g-2023/talk/review/CPDDPVUGSXUSTQ3JKS3H3ZWWUEQBSNSK) | TBD | Prizren, Kosovo | 28-30 June | EUR 490 registration fee + EUR ~400 flight + EUR ~300 hotel | April 4th | | TBD | TBD | TBD | TBD | TBD |
 | Paolo | Insogna| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 12th | 1190.23 EUR (Hotel) | Apr 13th, 2023 | TBD | TBD | TBD | TBD | TBD | TBD |
 | Ruy | Adorno| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 13th | 1282 USD (hotel) + 528 USD (flight) | Apr 25th, 2023 | https://github.com/openjs-foundation/community-fund/pull/25 | TBD | TBD | TBD | TBD | TBD |
+| Chris | Gervang | OpenJS World | Speaking | TBD | Vancouver | May 10th - May 14th | 1098.62 USD (hotel) + 844.08 USD (flight) | May 10th, 2023 | https://github.com/openjs-foundation/community-fund/pull/26 | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
Hello there, I'm a speaker at OpenJS World North America in Vancouver, CA on 12th. I unfortunately don't have funds to cover travel. I'd like to submit expenses for my flight from SFO, and an Airbnb. I've estimated the stipend amount to be $1,942.70. I plan to cover all food/transportation.

cc @openjs-foundation/cpc