### PR TITLE
chore: add claudio wunder expenses - openjs world EU 2023

### DIFF
--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -12,3 +12,4 @@
 | Paolo | Insogna| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 12th | 1190.23 EUR (Hotel) | Apr 13th, 2023 | TBD | TBD | TBD | TBD | TBD | TBD |
 | Ruy | Adorno| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 13th | 1282 USD (hotel) + 528 USD (flight) | Apr 25th, 2023 | https://github.com/openjs-foundation/community-fund/pull/25 | TBD | TBD | TBD | TBD | TBD |
 | Chris | Gervang | OpenJS World | Speaking | TBD | Vancouver | May 10th - May 14th | 1098.62 USD (hotel) + 844.08 USD (flight) | May 10th, 2023 | https://github.com/openjs-foundation/community-fund/pull/26 | TBD | TBD | TBD | TBD | TBD |
+| Claudio | Wunder | OpenJS World EU | Collab Summit Organisation + Programmee Committee | TBD | Bilbao, Spain | June 17th - June 21th | 1,097.00 EUR | TBD | https://github.com/openjs-foundation/community-fund/pull/27 | TBD | TBD | TBD | TBD | TBD |

--- a/programs/travel-fund/2023.md
+++ b/programs/travel-fund/2023.md
@@ -12,4 +12,4 @@
 | Paolo | Insogna| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 12th | 1190.23 EUR (Hotel) | Apr 13th, 2023 | TBD | TBD | TBD | TBD | TBD | TBD |
 | Ruy | Adorno| OpenJS World | Attendance + Collab Summit | TBD | Vancouver | May 8th - May 13th | 1282 USD (hotel) + 528 USD (flight) | Apr 25th, 2023 | https://github.com/openjs-foundation/community-fund/pull/25 | TBD | TBD | TBD | TBD | TBD |
 | Chris | Gervang | OpenJS World | Speaking | TBD | Vancouver | May 10th - May 14th | 1098.62 USD (hotel) + 844.08 USD (flight) | May 10th, 2023 | https://github.com/openjs-foundation/community-fund/pull/26 | TBD | TBD | TBD | TBD | TBD |
-| Claudio | Wunder | OpenJS World EU | Collab Summit Organisation + Programmee Committee | TBD | Bilbao, Spain | June 17th - June 21th | 1,097.00 EUR | TBD | https://github.com/openjs-foundation/community-fund/pull/27 | TBD | TBD | TBD | TBD | TBD |
+| Claudio | Wunder | OpenJS World EU | Collab Summit Organisation + Programmee Committee | TBD | Bilbao, Spain | September 17th - September 21th | 1,097.00 EUR | TBD | https://github.com/openjs-foundation/community-fund/pull/27 | TBD | TBD | TBD | TBD | TBD |


### PR DESCRIPTION
Request for: Collab Summit and OSSEU 2023
Dates: September 17th - September 21th
Travelling from: Porto, Portugal (Actually arriving on the 15th of September)
Flight: ~80 EUR (From Porto to Bilbao) and ~370 EUR (From Bilbao to Munich) 
Hotel: ~650 EUR
Transportation: ~0 EUR
Total: ~1,097.00 EUR

The member will pay all other costs like transportation and food.